### PR TITLE
IT-3544 | savePhrase supports elastic 7.x

### DIFF
--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -112,7 +112,7 @@ class ElasticsearchEngine extends Engine
     public function savePhrase($model, $params)
     {
         $this->elastic->index([
-            'index' => $model->searchableAs(),
+            'index' => $model->searchableAs() . '_search_phrases',
             'type'  => get_class($model) . '_search_phrases',
             'body'  => $params,
         ]);


### PR DESCRIPTION
Fixes: 
```
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Rejecting mapping update to [lek_slides] as the final mapping would have more than 1 type: [App\\Models\\Slide, App\\Models\\Slide_search_phrases]"}],"type":"illegal_argument_exception","reason":"Rejecting mapping update to [lek_slides] as the final mapping would have more than 1 type: [App\\Models\\Slide, App\\Models\\Slide_search_phrases]"},"status":400}
```